### PR TITLE
Compile stuff in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,18 +1,6 @@
-name: Build compiler w/ ant
+name: Ant
 on: [push]
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: "11"
-          distribution: "adopt"
-      - name: Compile .jar artifacts with ant
-        run: ant jar
-
   testScanner:
     runs-on: ubuntu-latest
     steps:
@@ -24,3 +12,16 @@ jobs:
           distribution: "adopt"
       - name: Compile .jar artifacts with ant
         run: ant testScanner
+
+  jar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Compile .jar artifacts with ant
+        run: ant jar
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,8 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: "make the lib/ dir"
+        run: mkdir lib
       - name: wget
         uses: wei/wget@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,14 @@
+name: Build compiler w/ ant
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Compile .jar artifacts with ant
+        run: ant jar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ jobs:
         with:
           java-version: "11"
           distribution: "adopt"
+      - name: wget
+        uses: wei/wget@v1
+        with:
+          args: -O lib/junit.jar https://repo1.maven.org/maven2/junit/junit/4.13/junit-4.13.jar
       - name: Compile .jar artifacts with ant
         run: ant testScanner
 
@@ -24,4 +28,3 @@ jobs:
           distribution: "adopt"
       - name: Compile .jar artifacts with ant
         run: ant jar
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,3 +12,15 @@ jobs:
           distribution: "adopt"
       - name: Compile .jar artifacts with ant
         run: ant jar
+
+  testScanner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Compile .jar artifacts with ant
+        run: ant testScanner


### PR DESCRIPTION
This is useful to see which branches work, and which don't work, which commit broke everything, etc (without having to do `git bisect`)...

As of this writing, it doesn't compile (because `JLiteralDouble` is referenced but not defined). I can rebase whenever the main branch is working again.