### PR TITLE
Add job with individual compile target tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Compile .jar artifacts with ant
         run: ant jar
 
-  individual compile tests:
+  "individualCompileTests":
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,17 @@ jobs:
           distribution: "adopt"
       - name: Compile .jar artifacts with ant
         run: ant jar
+
+  individual compile tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: "11"
+          distribution: "adopt"
+      - name: Compile .jar artifacts with ant
+        run: ant jar
+      - name: Simple Or
+        run: bin/j-- ./tests/pass/SimpleOr.java

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,5 +42,9 @@ jobs:
           distribution: "adopt"
       - name: Compile .jar artifacts with ant
         run: ant jar
-      - name: Simple Or
+      - name: SimpleOr
         run: bin/j-- ./tests/pass/SimpleOr.java
+      - name: AssignmentOps
+        run: bin/j-- ./tests/pass/AssignmentOps.java
+      - name: Double
+        run: bin/j-- ./tests/pass/Double.java

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,3 +48,7 @@ jobs:
         run: bin/j-- ./tests/pass/AssignmentOps.java
       - name: Double
         run: bin/j-- ./tests/pass/Double.java
+      - name: Colon
+        run: bin/j-- ./tests/pass/Colon.java
+      - name: MinusAssign
+        run: bin/j-- ./tests/pass/MinusAssign.java

--- a/tests/pass/SimpleAnd.java
+++ b/tests/pass/SimpleAnd.java
@@ -1,0 +1,7 @@
+package pass;
+
+public class SimpleAnd {
+    public static void main(String[] args) {
+        boolean trueAnd = true && true;
+    }
+}


### PR DESCRIPTION
We suffered a regression in the logical or parsing, after merging the assignment operator parsing.

We could have caught this before merging, if we had run the individual compilation tests in CI.